### PR TITLE
Correct plugin to work against Docker 25

### DIFF
--- a/.github/workflows/pr_workflow.yml
+++ b/.github/workflows/pr_workflow.yml
@@ -14,6 +14,7 @@ jobs:
           - "20.10" # 2020-12 --> EOL 2023-12-10
           - "23.0"  # 2023-02 --> EOL ?
           - "24.0"  # 2023-05 --> EOL ?
+          - "25.0"  # 2024-01 --> EOL ?
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -16,6 +16,7 @@ jobs:
           - "20.10" # 2020-12 --> EOL 2023-12-10
           - "23.0"  # 2023-02 --> EOL ?
           - "24.0"  # 2023-05 --> EOL ?
+          - "25.0"  # 2024-01 --> EOL ?
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add hack to override the way ImageInfo is parsed from Docker Engine

The VirtualSize field was deprecated in API 1.43 and removed in API 1.44 but we dont seem to actually rely on it. This hack overrides the class from inside the Spotify docker-client such that the field is considered optional from the API.

Still needs https://github.com/gocd-contrib/docker-swarm-elastic-agent-plugin/issues/245 as a longer term fix.